### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "images"
   ],
   "description": "Import Cityscapes to Supervisely",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "images"
   ],
   "description": "Import Cityscapes to Supervisely",
-  "docker_image": "supervisely/import-export:6.73.162",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -23,5 +23,5 @@
     ]
   },
   "poster": "https://github.com/supervisely-ecosystem/import-cityscapes/assets/57998637/359774eb-c9bf-41ec-a414-37bdc2f3bc6b",
-  "min_instance_version": "6.11.8"
+  "instance_version": "6.15.60"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.162
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
